### PR TITLE
Check in PUT /update-profile if fields were modified or not

### DIFF
--- a/public/js/editProfile.js
+++ b/public/js/editProfile.js
@@ -92,6 +92,11 @@ $(document).ready(function () {
         success: function () {
           window.location.href = "/users/profile";
         },
+        error: function (data) {
+          submitBtn.prop("disabled", false);
+          $("#error-message").html(data.responseJSON.error);
+          $("#error-message").removeClass("d-none");
+        },
       });
     } else {
       submitBtn.prop("disabled", false);

--- a/routes/users.js
+++ b/routes/users.js
@@ -280,6 +280,18 @@ router.put("/profile", async (request, response) => {
     const lastName = validateLastName(xss(requestPostData.lastName));
     const dateOfBirth = validateDateOfBirth(xss(requestPostData.dateOfBirth));
 
+    const userDetails = request.session.user;
+    if (
+      firstName === userDetails.firstName &&
+      lastName === userDetails.lastName &&
+      dateOfBirth === userDetails.dateOfBirth
+    ) {
+      throwError(
+        ErrorCode.BAD_REQUEST,
+        "No fields have been changed from their original values, so no update has occurred!"
+      );
+    }
+
     const user = await usersData.updateProfile(
       request.session.user._id,
       firstName,

--- a/views/users/update-profile.handlebars
+++ b/views/users/update-profile.handlebars
@@ -35,6 +35,8 @@
         </div>
     </div>
 
+    <p class="text-danger d-none" id="error-message"></p>
+
     {{#if hasErrors}}
         <ul class="error-list">
             {{#each errors}}


### PR DESCRIPTION
I was getting an error where if I was updating profile and didn't change any of the details in the placeholders, the site would not redirect to the profile page. This is because the data function for updating profile throws an error if the MongoDB modified count is not equal to 1, which checks out since we didn't change anything about the user's details.

So I made sure to check for that in the routes in `PUT update-profile` so we don't try to update the profile if no fields were changed.